### PR TITLE
Use importRecordId as an array index in updateItems().

### DIFF
--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -32,11 +32,17 @@ class Import extends AbstractJob
         $this->client->setHeaders(['Accept' => 'application/json']);
         $this->apiUrl = $this->getArg('api_url');
         $this->limit = $this->getArg('limit');
-
+        $comment = $this->getArg('comment');
+        $dspaceImportJson = [
+            'o:job' => ['o:id' => $this->job->getId()],
+            'comment' => $comment,
+            'added_count' => $this->addedCount,
+            'updated_count' => $this->updatedCount,
+        ];
         $response = $this->api->create('dspace_imports', $dspaceImportJson);
         $importRecordId = $response->getContent()->id();
         $this->importCollection($this->getArg('collection_link'));
-        $comment = $this->getArg('comment');
+        
         $dspaceImportJson = [
             'o:job' => ['o:id' => $this->job->getId()],
             'comment' => $comment,

--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -33,12 +33,6 @@ class Import extends AbstractJob
         $this->apiUrl = $this->getArg('api_url');
         $this->limit = $this->getArg('limit');
 
-        $dspaceImportJson = [
-            'o:job' => ['o:id' => $this->job->getId()],
-            'comment' => $comment,
-            'added_count' => $this->addedCount,
-            'updated_count' => $this->updatedCount,
-        ];
         $response = $this->api->create('dspace_imports', $dspaceImportJson);
         $importRecordId = $response->getContent()->id();
         $this->importCollection($this->getArg('collection_link'));

--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -328,7 +328,7 @@ class Import extends AbstractJob
         }
 
         foreach ($updateResponses as $importRecordId => $resourceReference) {
-            $toUpdateData = $toUpdate[$index];
+            $toUpdateData = $toUpdate[$importRecordId];
             $dspaceItemJson = [
                             'o:job' => ['o:id' => $this->job->getId()],
                             'remote_id' => $toUpdateData['remote_id'],


### PR DESCRIPTION
Fixes array index error in [src/Job/Import.php#L331](https://github.com/omeka-s-modules/DspaceConnector/blob/develop/src/Job/Import.php#L331)