### PR TITLE
Restyle collections section for clarity, avoid tables.

### DIFF
--- a/asset/css/dspace-connector.css
+++ b/asset/css/dspace-connector.css
@@ -1,20 +1,102 @@
-tbody th {
-    padding: 6px .5em;
+.repository {
+  border-bottom: 1px solid #dfdfdf;
+  margin-bottom: 12px;
 }
 
-tr.community:not(:first-child) th {
-    padding-top: 24px;
+.import-repository {
+  display: block;
+  margin-top: 6px;
 }
 
-th.description p {
-    margin: 0px;
+.expand-collapse-all {
+    width: 100%;
+    text-align: right;
 }
 
-tr.in-community {
+.name {
+    display: block;
+    font-weight: bold;
+}
+
+.communities {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.community {
+    width: calc(50% - .5rem);
+    margin-bottom: 1rem;
+    border-radius: 3px;
     position: relative;
-    left: 2%;
 }
 
-button.import-collection {
-    margin: 0 12px 0 0;
+@media screen and (max-width:640px) {
+    .community {
+        width: 100%;
+        margin: 0 0 1rem !important;
+    }
+}
+
+.community:nth-child(2n+1) {
+    margin-left: 1rem;
+}
+
+.community > .name,
+.community > .description {
+    background: #676767;
+    padding: 6px;
+    color: #fff;
+    border: 1px solid #676767;
+    border-width: 0 1px;
+}
+
+.community > .name {
+    display: block;
+    padding: 6px 2em 6px 6px;
+    border-radius: 3px 3px 0 0;
+    border-top-width: 1px;
+}
+
+.community > .description {
+    padding: 0 6px 6px;
+}
+
+.community .expand,
+.community .collapse {
+    width: 2rem;
+    position: absolute;
+    top: 0;
+    right: 0;
+    text-align: center;
+    padding: 6px;
+}
+
+.community > .expand,
+.community > .collapse {
+    color: #fff;
+}
+
+.collection {
+    padding: 6px;
+    border: 1px solid #dfdfdf;
+    position: relative;
+    border-width: 0 1px 1px;
+}
+
+.collection:nth-of-type(2n) {
+    background: rgba(0,0,0,.04);
+}
+
+.collection > .name, 
+.collection > .description {
+    margin-bottom: 6px;
+}
+
+.collection > .name {
+    padding: 0 2rem 0 0;
+}
+
+.import-collection {
+    margin-bottom: 6px;
 }

--- a/asset/js/dspace-connector.js
+++ b/asset/js/dspace-connector.js
@@ -1,0 +1,10 @@
+(function($) {
+    $(document).ready(function() {
+        $('#expand-all').on('click', function() {
+            $('.communities .expand').click();
+        });
+        $('#collapse-all').on('click', function() {
+            $('.communities .collapse').click();
+        });
+    });
+})(jQuery)

--- a/view/dspace-connector/index/import.phtml
+++ b/view/dspace-connector/index/import.phtml
@@ -3,6 +3,7 @@ $form->prepare();
 $this->htmlElement('body')->appendAttribute('class', 'no-section-hashes');
 $escapeHtml = $this->plugin('escapeHtml');
 $this->headLink()->appendStylesheet($this->assetUrl('css/dspace-connector.css', 'DspaceConnector'));
+$this->headScript()->appendFile($this->assetUrl('js/dspace-connector.js', 'DspaceConnector'));
 ?>
 
 <?php echo $this->pageTitle($this->translate('Dspace Connector'), 1, $this->translate('Import options')); ?>
@@ -19,46 +20,53 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/dspace-connector.css', 
 </fieldset>
 
 <fieldset id="collections" class="section">
-    <table>
-        <tbody>
-            <tr class="repository">
-                 <td class="description"><?php echo $this->translate('Import all items in the DSpace repository, without separating by community or collection:'); ?></td>
-                 <td>
-                     <button class='import-repository' name='collection_link' value='<?php echo $repository; ?>'><?php echo $this->escapeHtml($this->translate('Import entire repository')); ?></button>
-                 </td>
-             </tr>
-            <?php foreach($communities as $community): ?>
-            <tr class="community">
-                <th class="name"><?php echo($community['name']); ?></th>
-                <?php if (!empty($community['shortDescription'])): ?>
-                <th class="description"><?php echo $community['shortDescription']; ?></th>
-                <?php elseif (!empty($community['introductoryText'])): ?>
-                <th class="description"><?php echo $community['introductoryText']; ?></th>
-                <?php else: ?>
-                <th class="description"><?php echo $this->translate('[No description given]'); ?></th>
-                <?php endif;?>
-            </tr>
-
+    <div class="repository">
+        <?php echo $this->translate('Import all items in the DSpace repository, without separating by community or collection'); ?>
+        <button class='import-repository' name='collection_link' value='<?php echo $repository; ?>'><?php echo $this->escapeHtml($this->translate('Import entire repository')); ?></button>
+    </div>
+    <div class="communities">
+        <div class="expand-collapse-all">
+            <button type="button" id="expand-all"><?php echo $this->translate('Expand all'); ?></button>
+            <button type="button" id="collapse-all"><?php echo $this->translate('Collapse all'); ?></button>
+        </div>
+        <?php foreach($communities as $community): ?>
+        <div class="community">
+            <span class="name"><?php echo($community['name']); ?></span>
+            <?php if (!empty($community['shortDescription']) || !empty($community['introductoryText'])): ?>
+                <a href="#" class="expand" aria-label=" <?php echo $this->escapeHtml($this->translate('Expand')); ?>"></a>
+                <div class="description collapsible">
+                    <?php if (!empty($community['shortDescription'])): ?>
+                    <?php echo $community['shortDescription']; ?>
+                    <?php elseif (!empty($community['introductoryText'])): ?>
+                    <?php echo $community['introductoryText']; ?>
+                    <?php endif;?>
+                </div>
+            <?php endif; ?>
+            <?php if (count($community['collections']) > 0): ?>
+                <div class="collections">
                 <?php foreach($community['collections'] as $collection): ?>
-                <tr class="collection">
-                    <td>
-                        <button class='import-collection' name='collection_link' value='<?php echo $collection['link']; ?>'><?php echo $this->escapeHtml($this->translate('Import collection')); ?></button>
-                    </td>
-                    <td class="name">
+                    <div class="collection">
                         <span class="name"><?php echo $collection['name']; ?></span>
-                    </td>
-                    <?php if (!empty($collection['shortDescription'])): ?>
-                    <td class="description"><?php echo $collection['shortDescription']; ?></td>
-                    <?php elseif (!empty($collection['introductoryText'])): ?>
-                    <td class="description"><?php echo $collection['introductoryText']; ?></td>
-                    <?php else: ?>
-                    <td class="description"><?php echo $this->translate('[No description given]'); ?></td>
-                    <?php endif; ?>
-                </tr>
+                        <?php if (!empty($community['shortDescription']) || !empty($community['introductoryText'])): ?>
+                        <a href="#" class="expand" aria-label=" <?php echo $this->escapeHtml($this->translate('Expand')); ?>"></a>
+                        <div class="description collapsible">
+                            <?php if (!empty($collection['shortDescription'])): ?>
+                            <?php echo $collection['shortDescription']; ?></td>
+                            <?php elseif (!empty($collection['introductoryText'])): ?>
+                            <?php echo $collection['introductoryText']; ?>
+                            <?php endif; ?>
+                        </div>
+                        <?php endif; ?>
+                        <button class='import-collection' name='collection_link' value='<?php echo $collection['link']; ?>'><?php echo $this->escapeHtml($this->translate('Import collection')); ?></button>
+                    </div>
                 <?php endforeach; ?>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
+                </div>
+            <?php else: ?>
+                <div class="no-results collection"><?php echo $this->translate('No collections.'); ?></div>
+            <?php endif; ?>
+        </div>
+        <?php endforeach; ?>
+        </div>
 </fieldset>
 
 <input type='hidden' name='api_url' value='<?php echo $dspace_url; ?>' ></input>


### PR DESCRIPTION
* The current use of tables to display the collections and communities does not make a lot of semantic sense. I
revised the markup to use divs and flexbox for layout. 
* I also added more background color accents to help with readability, as requested in #72.
* Descriptions can get unwieldy, so I included collapsible toggles for them. For users who prefer to see them all, there is an "expand all" button, as well as an undo with "collapse all".